### PR TITLE
[SPT-77] Point segmentation complete revamp

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -685,18 +685,19 @@ async def get_point_cutouts(data: PointSegmentationRequest):
 
         # Create the cutout
         img_crop = original_image[y:y+h, x:x+w]  # Crop the image (BGR)
-        mask_crop = mask[y:y+h, x:x+w]           # Crop the mask
+        mask_crop = mask[y:y+h, x:x+w]            # Crop the mask
         img_crop_rgba = cv2.cvtColor(img_crop, cv2.COLOR_BGR2RGBA)  # Convert to RGBA
-        img_crop_rgba[:, :, 3] = mask_crop  # Set alpha channel (255 where mask is True)
+        alpha_mask_crop = np.where(mask_crop > 0, 255, 0).astype(np.uint8)
+        img_crop_rgba[:, :, 3] = alpha_mask_crop # Set alpha channel
 
         # Create the puzzle outline
-        original_rgba = cv2.cvtColor(original_image, cv2.COLOR_BGR2RGBA)  # Full image to RGBA
-        alpha_channel = np.where(mask == 0, 255, 0).astype(np.uint8)      # Transparent where mask is True
+        original_rgba = cv2.cvtColor(original_image, cv2.COLOR_BGR2RGBA) # Full image to RGBA
+        alpha_channel = np.where(mask == 0, 255, 0).astype(np.uint8)     # Transparent where mask is True
         original_rgba[:, :, 3] = alpha_channel
 
         # Convert to PIL Images for PNG saving
-        pil_cutout = Image.fromarray(cv2.cvtColor(img_crop_rgba, cv2.COLOR_BGRA2RGBA), 'RGBA')
-        pil_outline = Image.fromarray(cv2.cvtColor(original_rgba, cv2.COLOR_BGRA2RGBA), 'RGBA')
+        pil_cutout = Image.fromarray(img_crop_rgba, 'RGBA')
+        pil_outline = Image.fromarray(original_rgba, 'RGBA')
 
         # Upload the cutout to Cloudinary
         cutout_buffer = io.BytesIO()

--- a/client/src/components/LandingPage.css
+++ b/client/src/components/LandingPage.css
@@ -288,10 +288,11 @@ html, body {
   padding: 0 1rem;
 }
 
-.section-title {
+.landing-page .section-title {
   font-size: 2.5rem;
   font-weight: bold;
-  text-shadow: 0 0 2px #FFFFFF, 0 0 10px #D774E4;
+  color: white;
+  text-shadow: 0 0 2px #FFFFFF, 0 0 15px #4A90E2, 0 0 10px #D774E4;
 }
 
 /* Style for each line */

--- a/client/src/pages/teachers/PointSegmentation.css
+++ b/client/src/pages/teachers/PointSegmentation.css
@@ -61,7 +61,7 @@
 }
 
 /* Sidebar */
-.sidebar {
+.point-segmentation-container .point-sidebar {
   width: 300px;
   background-color: rgb(3, 3, 26);
   border-radius: 10px;
@@ -70,12 +70,12 @@
   overflow: hidden;
 }
 
-.sidebar.open {
+.point-sidebar.open {
   width: 300px;
   min-width: 300px;
 }
 
-.sidebar.closed {
+.point-sidebar.closed {
   width: 50px;
   min-width: 50px;
 }
@@ -98,7 +98,7 @@
   transition: opacity 0.3s;
 }
 
-.sidebar.closed .sidebar-header h2 {
+.point-sidebar.closed .sidebar-header h2 {
   opacity: 0;
 }
 
@@ -126,8 +126,8 @@
   gap: 15px;
 }
 
-.sidebar.closed .saved-cutouts-container,
-.sidebar.closed .cumulative-outline-container {
+.point-sidebar.closed .saved-cutouts-container,
+.point-sidebar.closed .cumulative-outline-container {
   display: none;
 }
 
@@ -479,7 +479,7 @@ button:disabled {
     flex-direction: column;
   }
   
-  .sidebar.open {
+  .point-sidebar.open {
     width: 100%;
     min-width: 100%;
   }

--- a/client/src/pages/teachers/PointSegmentation.css
+++ b/client/src/pages/teachers/PointSegmentation.css
@@ -2,7 +2,7 @@
 
 /* Main container */
 .point-segmentation-container {
-  max-width: 1200px;
+  max-width: 1500px;
   margin: 0 auto;
   padding: 20px;
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
@@ -40,6 +40,144 @@
   border-radius: 4px;
 }
 
+/* Layout with sidebar */
+.main-content-with-sidebar {
+  display: flex;
+  gap: 20px;
+  min-height: 500px;
+}
+
+.main-content {
+  flex: 1;
+  transition: width 0.3s ease;
+}
+
+.main-content.sidebar-open {
+  width: calc(100% - 300px);
+}
+
+.main-content.sidebar-closed {
+  width: 100%;
+}
+
+/* Sidebar */
+.sidebar {
+  width: 300px;
+  background-color: rgb(3, 3, 26);
+  border-radius: 10px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  transition: all 0.3s ease;
+  overflow: hidden;
+}
+
+.sidebar.open {
+  width: 300px;
+  min-width: 300px;
+}
+
+.sidebar.closed {
+  width: 50px;
+  min-width: 50px;
+}
+
+.sidebar-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 15px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.sidebar-header h2 {
+  margin: 0;
+  color: white;
+  font-size: 1.2rem;
+  white-space: nowrap;
+  overflow: hidden;
+  opacity: 1;
+  transition: opacity 0.3s;
+}
+
+.sidebar.closed .sidebar-header h2 {
+  opacity: 0;
+}
+
+.toggle-sidebar-button {
+  background-color: transparent;
+  color: white;
+  border: none;
+  font-size: 18px;
+  cursor: pointer;
+  padding: 5px 10px;
+  transition: background-color 0.3s;
+  border-radius: 4px;
+}
+
+.toggle-sidebar-button:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.saved-cutouts-container {
+  padding: 15px;
+  max-height: 500px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.sidebar.closed .saved-cutouts-container,
+.sidebar.closed .cumulative-outline-container {
+  display: none;
+}
+
+.no-cutouts {
+  color: #999;
+  text-align: center;
+  padding: 20px 0;
+}
+
+.saved-cutout-item {
+  background-color: rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  padding: 10px;
+  position: relative;
+  transition: transform 0.2s;
+}
+
+.saved-cutout-item:hover {
+  transform: translateY(-2px);
+}
+
+.remove-cutout-button {
+  background-color: rgba(255, 0, 0, 0.7);
+  color: white;
+  border: none;
+  border-radius: 4px;
+  padding: 5px 10px;
+  margin-top: 8px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  width: 100%;
+  transition: background-color 0.3s;
+}
+
+.remove-cutout-button:hover {
+  background-color: rgba(255, 0, 0, 0.9);
+}
+
+.cumulative-outline-container {
+  padding: 15px;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.cumulative-outline-container h3 {
+  color: white;
+  font-size: 1rem;
+  margin-top: 0;
+  margin-bottom: 10px;
+}
+
 /* Sections */
 .upload-section,
 .selection-mode-section,
@@ -54,14 +192,14 @@
 }
 
 section h2 {
-  color: #333;
+  color: white;
   margin-top: 0;
   margin-bottom: 20px;
   font-size: 1.5rem;
 }
 
 section h3 {
-  color: #555;
+  color: #ccc;
   margin-top: 15px;
   margin-bottom: 15px;
   font-size: 1.2rem;
@@ -153,7 +291,7 @@ button:disabled {
   text-align: center;
   margin-bottom: 15px;
   font-size: 0.9rem;
-  color: #666;
+  color: #ccc;
 }
 
 /* Image and Canvas */
@@ -210,66 +348,21 @@ button:disabled {
   background-color: #7b1fa2;
 }
 
-/* Cutouts section */
-.cutouts-container {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 20px;
-  justify-content: center;
-  margin-bottom: 25px;
-}
-
-.cutout-item {
-  background-color: rgba(255, 255, 255, 0.05);
-  padding: 15px;
-  border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  text-align: center;
-  transition: transform 0.2s;
-}
-
-.cutout-item:hover {
-  transform: scale(1.03);
-}
-
-.cutout-item img {
-  border-radius: 4px;
-  display: block;
-}
-
-.puzzle-outline-container {
-  text-align: center;
-  margin-top: 30px;
-  padding: 15px;
-  background-color: rgba(255, 255, 255, 0.05);
-  border-radius: 8px;
-}
-
-.puzzle-outline-container h3 {
-  margin-bottom: 15px;
-}
-
-/* Result section */
-.result-container {
-  display: flex;
-  justify-content: center;
-  margin-bottom: 20px;
-}
-
-.mask-image {
-  max-width: 100%;
-  height: auto;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  border-radius: 4px;
-}
-
-.actions-buttons {
-  display: flex;
-  justify-content: center;
-}
-
 /* Responsive design */
 @media (max-width: 768px) {
+  .main-content-with-sidebar {
+    flex-direction: column;
+  }
+  
+  .sidebar.open {
+    width: 100%;
+    min-width: 100%;
+  }
+  
+  .main-content.sidebar-open {
+    width: 100%;
+  }
+  
   .mode-buttons {
     flex-direction: column;
     align-items: center;
@@ -278,10 +371,5 @@ button:disabled {
   .mode-button {
     width: 100%;
     max-width: 100%;
-  }
-
-  .cutouts-container {
-    flex-direction: column;
-    align-items: center;
   }
 }

--- a/client/src/pages/teachers/PointSegmentation.css
+++ b/client/src/pages/teachers/PointSegmentation.css
@@ -160,8 +160,6 @@
     margin-bottom: 20px;
     max-width: 100%;
     overflow: hidden;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-    border-radius: 4px;
   }
   
   .segmentation-image {

--- a/client/src/pages/teachers/PointSegmentation.css
+++ b/client/src/pages/teachers/PointSegmentation.css
@@ -2,227 +2,286 @@
 
 /* Main container */
 .point-segmentation-container {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 20px;
-    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  }
-  
-  /* Header */
-  .segmentation-header {
-    text-align: center;
-    margin-bottom: 2rem;
-  }
-  
-  .segmentation-header h1 {
-    color: white;
-    font-size: 2.5rem;
-    margin: 0;
-    padding: 16px;
-  }
-  
-  /* Messages */
-  .error-message {
-    background-color: rgba(255, 0, 0, 0.1);
-    border-left: 4px solid #f44336;
-    color: #721c24;
-    padding: 12px;
-    margin-bottom: 20px;
-    border-radius: 4px;
-  }
-  
-  .success-message {
-    background-color: rgba(0, 255, 0, 0.1);
-    border-left: 4px solid #4caf50;
-    color: #155724;
-    padding: 12px;
-    margin-bottom: 20px;
-    border-radius: 4px;
-  }
-  
-  /* Sections */
-  .upload-section,
-  .selection-mode-section,
-  .image-interaction-section,
-  .result-section {
-    background-color: rgb(1, 1, 17);
-    border-radius: 10px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-    padding: 20px;
-    margin-bottom: 30px;
-  }
-  
-  section h2 {
-    color: #333;
-    margin-top: 0;
-    margin-bottom: 20px;
-    font-size: 1.5rem;
-  }
-  
-  /* File upload */
-  .upload-container {
-    display: flex;
-    justify-content: center;
-    margin-bottom: 20px;
-  }
-  
-  .file-upload-label {
-    display: inline-block;
-    cursor: pointer;
-  }
-  
-  .file-input {
-    display: none;
-  }
-  
-  .upload-button {
-    display: inline-block;
-    background-color: #4a6cb3;
-    color: white;
-    padding: 12px 24px;
-    border-radius: 4px;
-    font-weight: 600;
-    transition: background-color 0.3s;
-  }
-  
-  .upload-button:hover {
-    background-color: #3a5da3;
-  }
-  
-  /* Buttons */
-  button {
-    cursor: pointer;
-    padding: 10px 18px;
-    background-color: #4a6cb3;
-    color: white;
-    border: none;
-    border-radius: 4px;
-    font-weight: 600;
-    transition: all 0.3s;
-    margin-right: 10px;
-    margin-bottom: 10px;
-  }
-  
-  button:hover {
-    background-color: #3a5da3;
-    transform: translateY(-2px);
-  }
-  
-  button:disabled {
-    background-color: #cccccc;
-    cursor: not-allowed;
-    transform: none;
-  }
-  
-  .generate-button {
-    display: block;
-    margin: 0 auto;
-    padding: 12px 24px;
-    font-size: 1rem;
-  }
-  
-  /* Selection mode */
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 20px;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+/* Header */
+.segmentation-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.segmentation-header h1 {
+  color: white;
+  font-size: 2.5rem;
+  margin: 0;
+  padding: 16px;
+}
+
+/* Messages */
+.error-message {
+  background-color: rgba(255, 0, 0, 0.1);
+  border-left: 4px solid #f44336;
+  color: #721c24;
+  padding: 12px;
+  margin-bottom: 20px;
+  border-radius: 4px;
+}
+
+.success-message {
+  background-color: rgba(0, 255, 0, 0.1);
+  border-left: 4px solid #4caf50;
+  color: #155724;
+  padding: 12px;
+  margin-bottom: 20px;
+  border-radius: 4px;
+}
+
+/* Sections */
+.upload-section,
+.selection-mode-section,
+.image-interaction-section,
+.result-section,
+.cutouts-section {
+  background-color: rgb(1, 1, 17);
+  border-radius: 10px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  padding: 20px;
+  margin-bottom: 30px;
+}
+
+section h2 {
+  color: #333;
+  margin-top: 0;
+  margin-bottom: 20px;
+  font-size: 1.5rem;
+}
+
+section h3 {
+  color: #555;
+  margin-top: 15px;
+  margin-bottom: 15px;
+  font-size: 1.2rem;
+}
+
+/* File upload */
+.upload-container {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 20px;
+}
+
+.file-upload-label {
+  display: inline-block;
+  cursor: pointer;
+}
+
+.file-input {
+  display: none;
+}
+
+.upload-button {
+  display: inline-block;
+  background-color: #4a6cb3;
+  color: white;
+  padding: 12px 24px;
+  border-radius: 4px;
+  font-weight: 600;
+  transition: background-color 0.3s;
+}
+
+.upload-button:hover {
+  background-color: #3a5da3;
+}
+
+/* Buttons */
+button {
+  cursor: pointer;
+  padding: 10px 18px;
+  background-color: #4a6cb3;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-weight: 600;
+  transition: all 0.3s;
+  margin-right: 10px;
+  margin-bottom: 10px;
+}
+
+button:hover {
+  background-color: #3a5da3;
+  transform: translateY(-2px);
+}
+
+button:disabled {
+  background-color: #cccccc;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.generate-button {
+  display: block;
+  margin: 0 auto;
+  padding: 12px 24px;
+  font-size: 1rem;
+}
+
+/* Selection mode */
+.mode-buttons {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 15px;
+  gap: 10px;
+}
+
+.mode-button {
+  flex: 1;
+  max-width: 200px;
+  padding: 12px;
+  text-align: center;
+}
+
+.mode-button.active {
+  background-color: #333;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+}
+
+.selection-instructions {
+  text-align: center;
+  margin-bottom: 15px;
+  font-size: 0.9rem;
+  color: #666;
+}
+
+/* Image and Canvas */
+.image-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.image-canvas-wrapper {
+  position: relative;
+  margin-bottom: 20px;
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.segmentation-image {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+.selection-canvas {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  cursor: crosshair;
+}
+
+/* Control buttons */
+.control-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px;
+  margin-top: 15px;
+}
+
+.segment-button {
+  background-color: #28a745;
+}
+
+.segment-button:hover {
+  background-color: #218838;
+}
+
+.cutout-button {
+  background-color: #9c27b0;
+}
+
+.cutout-button:hover {
+  background-color: #7b1fa2;
+}
+
+/* Cutouts section */
+.cutouts-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+  justify-content: center;
+  margin-bottom: 25px;
+}
+
+.cutout-item {
+  background-color: rgba(255, 255, 255, 0.05);
+  padding: 15px;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  text-align: center;
+  transition: transform 0.2s;
+}
+
+.cutout-item:hover {
+  transform: scale(1.03);
+}
+
+.cutout-item img {
+  border-radius: 4px;
+  display: block;
+}
+
+.puzzle-outline-container {
+  text-align: center;
+  margin-top: 30px;
+  padding: 15px;
+  background-color: rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+}
+
+.puzzle-outline-container h3 {
+  margin-bottom: 15px;
+}
+
+/* Result section */
+.result-container {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 20px;
+}
+
+.mask-image {
+  max-width: 100%;
+  height: auto;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  border-radius: 4px;
+}
+
+.actions-buttons {
+  display: flex;
+  justify-content: center;
+}
+
+/* Responsive design */
+@media (max-width: 768px) {
   .mode-buttons {
-    display: flex;
-    justify-content: center;
-    margin-bottom: 15px;
-    gap: 10px;
-  }
-  
-  .mode-button {
-    flex: 1;
-    max-width: 200px;
-    padding: 12px;
-    text-align: center;
-  }
-  
-  .mode-button.active {
-    background-color: #333;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
-  }
-  
-  .selection-instructions {
-    text-align: center;
-    margin-bottom: 15px;
-    font-size: 0.9rem;
-    color: #666;
-  }
-  
-  /* Image and Canvas */
-  .image-container {
-    display: flex;
     flex-direction: column;
     align-items: center;
   }
   
-  .image-canvas-wrapper {
-    position: relative;
-    margin-bottom: 20px;
-    max-width: 100%;
-    overflow: hidden;
-  }
-  
-  .segmentation-image {
-    display: block;
-    max-width: 100%;
-    height: auto;
-  }
-  
-  .selection-canvas {
-    position: absolute;
-    top: 0;
-    left: 0;
+  .mode-button {
     width: 100%;
-    height: 100%;
-    cursor: crosshair;
-  }
-  
-  /* Control buttons */
-  .control-buttons {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 10px;
-    margin-top: 15px;
-  }
-  
-  .segment-button {
-    background-color: #28a745;
-    margin-left: 10px;
-  }
-  
-  .segment-button:hover {
-    background-color: #218838;
-  }
-  
-  /* Result section */
-  .result-container {
-    display: flex;
-    justify-content: center;
-    margin-bottom: 20px;
-  }
-  
-  .mask-image {
     max-width: 100%;
-    height: auto;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-    border-radius: 4px;
   }
-  
-  .actions-buttons {
-    display: flex;
-    justify-content: center;
+
+  .cutouts-container {
+    flex-direction: column;
+    align-items: center;
   }
-  
-  /* Responsive design */
-  @media (max-width: 768px) {
-    .mode-buttons {
-      flex-direction: column;
-      align-items: center;
-    }
-    
-    .mode-button {
-      width: 100%;
-      max-width: 100%;
-    }
-  }
+}

--- a/client/src/pages/teachers/PointSegmentation.css
+++ b/client/src/pages/teachers/PointSegmentation.css
@@ -378,6 +378,16 @@ button:disabled {
   opacity: 0.2;
 }
 
+.neural-animation-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 8;
+}
+
 @keyframes particleFlow {
   0% {
     transform: translateY(-20px) translateX(-20px);

--- a/client/src/pages/teachers/PointSegmentation.css
+++ b/client/src/pages/teachers/PointSegmentation.css
@@ -348,6 +348,117 @@ button:disabled {
   background-color: #7b1fa2;
 }
 
+/* Neural Network Animation */
+.neural-animation {
+  position: relative;
+  height: 60px;
+  margin-bottom: 20px;
+  overflow: hidden;
+}
+
+.neural-particles {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background: 
+    radial-gradient(circle, #4a9eff 1px, transparent 1px),
+    radial-gradient(circle, #4a9eff 1px, transparent 1px);
+  background-size: 20px 20px;
+  animation: particleFlow 3s linear infinite;
+  opacity: 0.5;
+}
+
+.neural-particles:nth-child(2) {
+  animation-delay: -1s;
+  opacity: 0.3;
+}
+
+.neural-particles:nth-child(3) {
+  animation-delay: -2s;
+  opacity: 0.2;
+}
+
+@keyframes particleFlow {
+  0% {
+    transform: translateY(-20px) translateX(-20px);
+  }
+  100% {
+    transform: translateY(20px) translateX(20px);
+  }
+}
+
+/* Progress Bar */
+.simulation-bar-container {
+  width: 100%;
+  padding: 10px;
+}
+
+.simulation-bar {
+  height: 6px;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 3px;
+  position: relative;
+  overflow: hidden;
+}
+
+.simulation-progress {
+  height: 100%;
+  background: linear-gradient(90deg, #4a9eff, #8ed6ff);
+  border-radius: 3px;
+  position: relative;
+  transition: width 0.3s ease-out;
+}
+
+.simulation-progress::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(255, 255, 255, 0.3),
+    transparent
+  );
+  animation: shimmer 1.5s infinite;
+}
+
+.simulation-glow {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  filter: blur(5px);
+  background: inherit;
+  opacity: 0.5;
+}
+
+@keyframes shimmer {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+.simulation-percentage {
+  font-size: 24px;
+  font-weight: bold;
+  margin: 15px 0;
+  text-shadow: 0 0 10px rgba(74, 158, 255, 0.8);
+}
+
+.simulation-message {
+  font-size: 16px;
+  opacity: 0.9;
+  margin-top: 10px;
+  color: #8ed6ff;
+}
+
 /* Responsive design */
 @media (max-width: 768px) {
   .main-content-with-sidebar {

--- a/client/src/pages/teachers/PointSegmentation.css
+++ b/client/src/pages/teachers/PointSegmentation.css
@@ -314,6 +314,10 @@ button:disabled {
   height: auto;
 }
 
+.segmentation-image.dull-image {
+  filter: brightness(0.3);
+}
+
 .selection-canvas {
   position: absolute;
   top: 0;

--- a/client/src/pages/teachers/PointSegmentation.js
+++ b/client/src/pages/teachers/PointSegmentation.js
@@ -195,21 +195,22 @@ const PointSegmentation = () => {
       const scaleY = canvas.height / imageSize.height;
       
       ctx.beginPath();
-      ctx.arc(point.x * scaleX, point.y * scaleY, 5, 0, 2 * Math.PI);
+      // Increase radius from 5 to 7 for better visibility
+      ctx.arc(point.x * scaleX, point.y * scaleY, 7, 0, 2 * Math.PI);
       
-      // Different colors for foreground/background points
-      if (labels[index] === 1) {
-        ctx.fillStyle = 'green'; // Foreground points
-      } else {
-        ctx.fillStyle = 'red';   // Background points
-      }
-      
+      // Set point fill color based on label
+      ctx.fillStyle = labels[index] === 1 ? 'green' : 'red';
       ctx.fill();
+      
+      // Add a white border stroke to help the point stand out
+      ctx.strokeStyle = 'white';
+      ctx.lineWidth = 2;
+      ctx.stroke();
       
       // Add point number
       ctx.fillStyle = 'white';
       ctx.font = '10px Arial';
-      ctx.fillText(index + 1, point.x * scaleX + 7, point.y * scaleY + 7);
+      ctx.fillText(index + 1, point.x * scaleX + 9, point.y * scaleY + 9);
     });
   };
 
@@ -446,7 +447,7 @@ const PointSegmentation = () => {
                     ref={imageRef}
                     src={imagePreview} 
                     alt="Uploaded preview" 
-                    className="segmentation-image"
+                    className={`segmentation-image ${simulationVisible ? 'dull-image' : ''}`}
                   />
                   {maskUrl && (
                     <img

--- a/client/src/pages/teachers/PointSegmentation.js
+++ b/client/src/pages/teachers/PointSegmentation.js
@@ -472,15 +472,6 @@ const PointSegmentation = () => {
                   />
                   {simulationVisible && (
                     <>
-                      <div className="simulation-background" style={{
-                        position: 'absolute',
-                        top: 0,
-                        left: 0,
-                        width: '100%',
-                        height: '100%',
-                        backgroundColor: 'rgba(0, 0, 0, 0.7)', // Dark semi-transparent overlay
-                        zIndex: 9,
-                      }}/>
                       <div className="simulation-overlay" style={{
                         position: 'absolute',
                         top: '50%',
@@ -495,11 +486,6 @@ const PointSegmentation = () => {
                         backdropFilter: 'blur(8px)',
                         width: '400px',
                       }}>
-                        <div className="neural-animation">
-                          <div className="neural-particles"></div>
-                          <div className="neural-particles"></div>
-                          <div className="neural-particles"></div>
-                        </div>
                         <div className="simulation-bar-container">
                           <div className="simulation-bar">
                             <div className="simulation-progress" style={{
@@ -514,6 +500,11 @@ const PointSegmentation = () => {
                         <div className="simulation-message">
                           {simulationMessage}
                         </div>
+                      </div>
+                      <div className="neural-animation-overlay">
+                        <div className="neural-particles"></div>
+                        <div className="neural-particles"></div>
+                        <div className="neural-particles"></div>
                       </div>
                     </>
                   )}

--- a/client/src/pages/teachers/PointSegmentation.js
+++ b/client/src/pages/teachers/PointSegmentation.js
@@ -253,19 +253,36 @@ const PointSegmentation = () => {
       {imagePreview && (
         <section className="image-interaction-section">
           <div className="image-container">
-            <div className="image-canvas-wrapper">
-              <img 
-                ref={imageRef}
-                src={imagePreview} 
-                alt="Uploaded preview" 
-                className="segmentation-image"
+          <div className="image-canvas-wrapper">
+            <img 
+              ref={imageRef}
+              src={imagePreview} 
+              alt="Uploaded preview" 
+              className="segmentation-image"
+            />
+            {maskUrl && (
+              <img
+                src={maskUrl}
+                alt="Segmentation mask"
+                className="mask-overlay"
+                style={{
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  width: '100%',
+                  height: '100%',
+                  objectFit: 'contain',
+                  opacity: 0.5, // Translucent overlay
+                  pointerEvents: 'none', // Allows clicks to pass through to the canvas
+                }}
               />
-              <canvas 
-                ref={canvasRef}
-                className="selection-canvas"
-                onClick={handleCanvasClick}
-              />
-            </div>
+            )}
+            <canvas 
+              ref={canvasRef}
+              className="selection-canvas"
+              onClick={handleCanvasClick}
+            />
+          </div>
             
             {imageEmbeddingId && (
               <div className="control-buttons">
@@ -284,21 +301,6 @@ const PointSegmentation = () => {
                 </button>
               </div>
             )}
-          </div>
-        </section>
-      )}
-
-      {maskUrl && (
-        <section className="result-section">
-          <h2>Segmentation Result</h2>
-          <div className="result-container">
-            <img src={maskUrl} alt="Segmentation mask" className="mask-image" />
-          </div>
-          <div className="actions-buttons">
-            <button onClick={() => window.open(maskUrl, '_blank')}>
-              Download Full Size
-            </button>
-            {/* Add more actions as needed */}
           </div>
         </section>
       )}

--- a/client/src/pages/teachers/PointSegmentation.js
+++ b/client/src/pages/teachers/PointSegmentation.js
@@ -491,28 +491,27 @@ const PointSegmentation = () => {
                         zIndex: 10,
                         padding: '20px',
                         borderRadius: '10px',
+                        backgroundColor: 'rgba(0, 0, 0, 0.85)',
+                        backdropFilter: 'blur(8px)',
+                        width: '400px',
                       }}>
-                        <div className="simulation-bar-container" style={{
-                          width: '300px',
-                          height: '10px',
-                          backgroundColor: 'rgba(255, 255, 255, 0.2)',
-                          marginBottom: '15px',
-                          borderRadius: '5px',
-                          overflow: 'hidden',
-                        }}>
-                          <div className="simulation-bar" style={{
-                            height: '100%',
-                            width: simulationProgress + '%',
-                            backgroundColor: '#3498db', // More visible blue color
-                            transition: 'width 0.2s linear',
-                            boxShadow: '0 0 10px rgba(52, 152, 219, 0.5)', // Glow effect
-                          }}></div>
+                        <div className="neural-animation">
+                          <div className="neural-particles"></div>
+                          <div className="neural-particles"></div>
+                          <div className="neural-particles"></div>
                         </div>
-                        <div className="simulation-message" style={{
-                          fontSize: '18px',
-                          fontWeight: '500',
-                          textShadow: '0 2px 4px rgba(0,0,0,0.5)', // Text shadow for better visibility
-                        }}>
+                        <div className="simulation-bar-container">
+                          <div className="simulation-bar">
+                            <div className="simulation-progress" style={{
+                              width: `${simulationProgress}%`
+                            }}></div>
+                            <div className="simulation-glow"></div>
+                          </div>
+                        </div>
+                        <div className="simulation-percentage">
+                          {Math.round(simulationProgress)}%
+                        </div>
+                        <div className="simulation-message">
                           {simulationMessage}
                         </div>
                       </div>

--- a/client/src/pages/teachers/PointSegmentation.js
+++ b/client/src/pages/teachers/PointSegmentation.js
@@ -379,7 +379,7 @@ const PointSegmentation = () => {
 
       <div className="main-content-with-sidebar">
         {/* Sidebar for saved cutouts */}
-        <div className={`sidebar ${sidebarOpen ? 'open' : 'closed'}`}>
+        <div className={`point-sidebar ${sidebarOpen ? 'open' : 'closed'}`}>
           <div className="sidebar-header">
             <h2>Saved Cutouts</h2>
             <button 


### PR DESCRIPTION
## Point segmentation complete revamp

### Description
- It is built over the `PointSemgentation `module
- Inculcates the highlight segment code from `Label `module
- inculcates the cutout and puzzle outline from `Quiz` module
- Cutouts are  saved in the side in a sidebar.
- Every time cutout is clicked it should create a new cutout instead of including whatever was present into the cutout is done.
- Cumulative puzzle outline based on all the cutouts removed has been added.

### Notion ID
[SPT-77]

### ✅ Checklist
- [x] Tested changes locally
- [x] Updated PR documentation properly

### Testing Evidence 

Segmented part:
![image](https://github.com/user-attachments/assets/e4acf826-95c2-432b-b55d-093640c35325)

Cutouts:
![image](https://github.com/user-attachments/assets/c6a6b16c-e56e-490d-9253-b19acbecc0ce)

Outline after removing cutouts:
![image](https://github.com/user-attachments/assets/0a85e4e8-2c11-4a24-bc84-a2917dd95a93)

Sidebar:
![image](https://github.com/user-attachments/assets/91b12b1a-a837-4ee1-89c1-86f28e5b79f5)

### Future Issue

- Integration with the students side of things.
- Saving in the right format in the database to integrate it at the students side.

### Instructions to run 

- Download the SAM-VIT-h model from [here](https://github.com/facebookresearch/segment-anything).
- Place this model in the `backend` folder.
- Navigate to `Quiz mode` > `Manual Segmentation` and check the working