### PR TITLE
Responsive Create Notes Page

### DIFF
--- a/client/src/components/AddNotes.css
+++ b/client/src/components/AddNotes.css
@@ -549,3 +549,131 @@
     transform: rotate(360deg);
   }
 }
+
+/* Responsive Styles */
+@media (max-width: 1200px) {
+  .addnotes-container {
+    max-width: 1000px;
+  }
+}
+
+@media (max-width: 992px) {
+  .addnotes-container {
+    max-width: 800px;
+    padding: 20px;
+  }
+
+  .addnotes-header h2 {
+    font-size: 1.8rem;
+  }
+
+  .addnotes-header p {
+    font-size: 1rem;
+  }
+
+  .addnotes-panel {
+    width: 90%;
+    max-width: 450px;
+    padding: 24px;
+  }
+}
+
+@media (max-width: 768px) {
+  .addnotes-container {
+    max-width: 100%;
+    padding: 16px;
+    margin: 16px;
+  }
+
+  .addnotes-image-container {
+    /* Adjust image container if needed, maybe reduce max-height */
+  }
+
+  .addnotes-panel {
+    width: 95%;
+    padding: 20px;
+    max-height: 70vh; /* Allow more vertical space if needed */
+  }
+
+  .addnotes-panel h3 {
+    font-size: 1.4rem;
+  }
+
+  .addnotes-textarea {
+    min-height: 120px;
+    font-size: 0.9rem;
+  }
+
+  .addnotes-save-button,
+  .addnotes-cancel-button,
+  .addnotes-back-button,
+  .addnotes-done-button,
+  .addnotes-ai-button,
+  .addnotes-record-button {
+    padding: 12px;
+    font-size: 0.95rem;
+  }
+
+  .addnotes-footer {
+    flex-direction: column;
+    gap: 12px;
+    align-items: center;
+  }
+
+  .addnotes-back-button,
+  .addnotes-done-button {
+    width: 80%;
+  }
+}
+
+@media (max-width: 576px) {
+  .addnotes-header h2 {
+    font-size: 1.5rem;
+  }
+
+  .addnotes-header p {
+    font-size: 0.9rem;
+  }
+
+  .addnotes-panel {
+    padding: 16px;
+    gap: 16px;
+  }
+
+  .addnotes-panel h3 {
+    font-size: 1.3rem;
+  }
+
+  .addnotes-textarea {
+    min-height: 100px;
+  }
+
+   .addnotes-buttons {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .addnotes-save-button,
+  .addnotes-cancel-button,
+  .addnotes-back-button,
+  .addnotes-done-button,
+  .addnotes-ai-button,
+  .addnotes-record-button {
+    padding: 10px;
+    font-size: 0.9rem;
+  }
+
+  .addnotes-back-button,
+  .addnotes-done-button {
+    width: 90%;
+  }
+
+  .addnotes-tab {
+    padding: 8px 12px;
+    font-size: 0.9rem;
+  }
+
+  .addnotes-footer {
+    margin-top: 16px;
+  }
+}


### PR DESCRIPTION
## Responsive Create Notes Page

### Description
<!-- Please provide a summary of the changes in bullet points them. -->
- Updates the following file with bug fix <!-- Example -->
- AddNotes page is responsive

### Notion ID
<!-- Attach the notion ID here
Also put it in the name of the PR for uniformity as we have been doing so far -->


### ✅ Checklist
- [ ] Tested changes locally
- [ ] Updated documentation if necessary

### Testing Evidence 
<!-- Please provide visual changes of whatever is done.
If backend is changed provide proof of running in terminal. -->

![image](https://github.com/user-attachments/assets/4ad00dd5-bf1a-4af1-b1f7-6f4567e90c53)

![image](https://github.com/user-attachments/assets/dd1b461d-0b05-4ed3-98e8-9a31193c398d)

![image](https://github.com/user-attachments/assets/396bc937-e3c6-4b59-8f5d-e98700762105)

![image](https://github.com/user-attachments/assets/4db7f2c5-5121-4987-b415-9ea92793898b)

### Future Issue
<!-- This can be like None created or
This PR creates the following bug which can be fixed in the next upcoming PR. -->